### PR TITLE
Split bindings into separate file

### DIFF
--- a/.slate
+++ b/.slate
@@ -4,4 +4,5 @@
 alias dot-slate ~/path/to/repo/dot-slate/
 
 source ${dot-slate}/global.slate
+source ${dot-slate}/bindings.slate
 source ${dot-slate}/personal.slate

--- a/bindings.slate
+++ b/bindings.slate
@@ -1,0 +1,23 @@
+# Basic Bindings
+bind pad+:ctrl  ${resize-full}
+
+bind pad0:ctrl  ${half-left}
+bind pad.:ctrl  ${half-right}
+bind pad0:ctrl;alt  ${half-top}
+bind pad.:ctrl;alt  ${half-bottom}
+
+bind pad1:ctrl  ${trio-left}
+bind pad2:ctrl  ${trio-middle}
+bind pad3:ctrl  ${trio-right}
+
+bind pad4:ctrl  ${hex-lower-left}
+bind pad5:ctrl  ${hex-lower-middle}
+bind pad6:ctrl  ${hex-lower-right}
+bind pad7:ctrl  ${hex-upper-left}
+bind pad8:ctrl  ${hex-upper-middle}
+bind pad9:ctrl  ${hex-upper-right}
+
+bind pad1:ctrl;alt  ${quarter-lower-left}
+bind pad2:ctrl;alt  ${quarter-lower-right}
+bind pad4:ctrl;alt  ${quarter-upper-left}
+bind pad5:ctrl;alt  ${quarter-upper-right}

--- a/global.slate
+++ b/global.slate
@@ -165,27 +165,3 @@ alias 23S ${23L} | ${23M} | ${23R}
 alias 24S ${24TL} | ${24TR} | ${24BL} | ${24BR}
 alias 2HS ${2HTL} | ${2HTM} | ${2HTR} | ${2HBL} | ${2HBM} | ${2HBR}
 alias 26S ${26TL} | ${26ML} | ${26BL} | ${26TR} | ${26MR} | ${26BR}
-
-# Basic Bindings
-bind pad+:ctrl  ${resize-full}
-
-bind pad0:ctrl  ${half-left}
-bind pad.:ctrl  ${half-right}
-bind pad0:ctrl;alt  ${half-top}
-bind pad.:ctrl;alt  ${half-bottom}
-
-bind pad1:ctrl  ${trio-left}
-bind pad2:ctrl  ${trio-middle}
-bind pad3:ctrl  ${trio-right}
-
-bind pad4:ctrl  ${hex-lower-left}
-bind pad5:ctrl  ${hex-lower-middle}
-bind pad6:ctrl  ${hex-lower-right}
-bind pad7:ctrl  ${hex-upper-left}
-bind pad8:ctrl  ${hex-upper-middle}
-bind pad9:ctrl  ${hex-upper-right}
-
-bind pad1:ctrl;alt  ${quarter-lower-left}
-bind pad2:ctrl;alt  ${quarter-lower-right}
-bind pad4:ctrl;alt  ${quarter-upper-left}
-bind pad5:ctrl;alt  ${quarter-upper-right}


### PR DESCRIPTION
Allows a user to grab everything from `global.slate` without affecting
their system hotkeys
