### PR TITLE
Point to the actively-maintained fork of Slate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 
 ### What It Is
 
-Sharing my .slate setup for the wonderful Mac OS X Window manager namded Slate which can be
-found here: https://github.com/jigish/slate
+Sharing my .slate setup for the wonderful Mac OS X Window manager namded Slate, an active fork of which can be
+found here: https://github.com/mattr-/slate
+
+The original repository (https://github.com/jigish/slate) had its last commit in 2012.
 
 #### Special Features
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ### What It Is
 
-Sharing my .slate setup for the wonderful Mac OS X Window manager namded Slate, an active fork of which can be
+Sharing my .slate setup for the wonderful Mac OS X Window manager named Slate, an active fork of which can be
 found here: https://github.com/mattr-/slate
 
 The original repository (https://github.com/jigish/slate) had its last commit in 2012.


### PR DESCRIPTION
The original repo is stale (2012), so we should point to the actively-maintained fork of it, https://github.com/mattr-/slate
